### PR TITLE
Store/read recording watched state (play position) on the backend (DMS 2.1.2 or higher required)

### DIFF
--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,6 @@
+3.6.9
+[added] Store/resume recording watched state on the backend (DMS 2.1.2 or higher required)
+
 3.6.8
 [fixed] Fix stream read chunk size unit
 

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -599,6 +599,17 @@ bool Dvb::DeleteRecording(const PVR_RECORDING &recinfo)
   if (res.error)
     return false;
   PVR->TriggerRecordingUpdate();
+
+  //check backend version if kvstore is supported
+  if (m_backendVersion >= DMS_VERSION_NUM(2, 1, 2, 0))
+  {
+    //delete the kvstore entry
+    const httpResponse &res = GetFromAPI("api/store.html?action=delete&sec=%s&key=lastplaypos_%s",
+      DMS_GUID_KVSTORE, recinfo.strRecordingId);
+    if (res.error)
+      return false;
+  }
+
   return true;
 }
 
@@ -683,6 +694,59 @@ bool Dvb::GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[],
   *size = idx;
   XBMC->CloseFile(res.file);
   return true;
+}
+
+
+bool Dvb::SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition)
+{
+  //check backend version if kvstore is supported
+  if (m_backendVersion < DMS_VERSION_NUM(2, 1, 2, 0))
+  {
+    XBMC->Log(LOG_ERROR, "Backend server is too old. Cant store recording last played position");
+    return true;
+  }
+
+  XBMC->Log(LOG_DEBUG, "%s: set recording last played position for: %s (id=%s) to %d", __FUNCTION__,
+    recording.strTitle, recording.strRecordingId, lastplayedposition);
+
+  //store the kvstore entry
+  const httpResponse &res = GetFromAPI("api/store.html?action=write&sec=%s&key=lastplaypos_%s&value=%i",
+    DMS_GUID_KVSTORE, recording.strRecordingId, lastplayedposition);
+  if (res.error)
+    return false;
+
+  //update kvstore file on the backend (Writes the current state of the store
+  //to the file \config\AddOnStore.xml in the configuration folder, if there are changes.)
+  const httpResponse &res1 = GetFromAPI("api/store.html?action=updatefile");
+  if (res1.error)
+    return false;
+
+  return true;
+}
+
+int Dvb::GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
+{
+  //check backend version if kvstore is supported
+  if (m_backendVersion < DMS_VERSION_NUM(2, 1, 2, 0))
+  {
+    XBMC->Log(LOG_ERROR, "Backend server is too old. Cant get recording last played position");
+    return 0;
+  }
+
+  //read the kvstore entry
+  const httpResponse &res = GetFromAPI("api/store.html?action=read&sec=%s&key=lastplaypos_%s",
+    DMS_GUID_KVSTORE, recording.strRecordingId);
+  if (res.error)
+    return false;
+
+  //convert the result
+  int lastplayedposition = 0;
+  std::sscanf(res.content.c_str(), "%i", &lastplayedposition);
+
+  XBMC->Log(LOG_DEBUG, "%s: get recording last played position for: %s (id=%s) is %d", __FUNCTION__,
+    recording.strTitle, recording.strRecordingId, lastplayedposition);
+
+  return lastplayedposition;
 }
 
 /***************************************************************************

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -31,6 +31,8 @@
 #define DAY_SECS                     (24 * 60 * 60)
 #define DELPHI_DATE                  (25569)
 
+#define DMS_GUID_KVSTORE            "b3c542c3-34fa-482f-919e-251a3f4cb23b"
+
 namespace dvbviewer
 {
   std::string URLEncode(const std::string& data);
@@ -160,6 +162,8 @@ public:
   RecordingReader *OpenRecordedStream(const PVR_RECORDING &recinfo);
   bool GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[],
       int *size);
+  bool SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
+  int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
 
   bool OpenLiveStream(const PVR_CHANNEL &channelinfo);
   void CloseLiveStream();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -104,6 +104,8 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
  ***********************************************************/
 PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
+  unsigned int iver = 0;
+  if (DvbData && DvbData->IsConnected()) iver = DvbData->GetBackendVersion();
   pCapabilities->bSupportsEPG                = true;
   pCapabilities->bSupportsTV                 = true;
   pCapabilities->bSupportsRadio              = true;
@@ -116,7 +118,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bHandlesInputStream         = true;
   pCapabilities->bHandlesDemuxing            = false;
   pCapabilities->bSupportsRecordingPlayCount = false;
-  pCapabilities->bSupportsLastPlayedPosition = false;
+  pCapabilities->bSupportsLastPlayedPosition = (iver >= DMS_VERSION_NUM(2, 1, 2, 0) ? true : false);
   pCapabilities->bSupportsRecordingEdl       = true;
   pCapabilities->bSupportsRecordingsRename   = false;
   pCapabilities->bSupportsRecordingsLifetimeChange = false;
@@ -472,6 +474,24 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY edl[],
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
+PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition)
+{
+  return (DvbData && DvbData->IsConnected()
+    && DvbData->SetRecordingLastPlayedPosition(recording, lastplayedposition))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
+{
+  if (!DvbData)
+    return PVR_ERROR_SERVER_ERROR;
+
+  if (DvbData->IsConnected() == false)
+    return PVR_ERROR_SERVER_ERROR;
+
+  return DvbData->GetRecordingLastPlayedPosition(recording);
+}
+
 /** UNUSED API FUNCTIONS */
 void OnSystemSleep(void) {}
 void OnSystemWake(void) {}
@@ -491,9 +511,7 @@ void DemuxReset(void) {}
 void DemuxFlush(void) {}
 PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING&, int) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING&, int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
-int GetRecordingLastPlayedPosition(const PVR_RECORDING&) { return -1; }
 PVR_ERROR RenameRecording(const PVR_RECORDING&) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UndeleteRecording(const PVR_RECORDING&) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }


### PR DESCRIPTION
This PR adds the feature that is stores/reads the recording last played position to/from the DMS backend. So the recording watched states gets synced on all clients.
DMS 2.1.2 or higher required!

Hoping this is the right repo to create the PR.

@manuelm Have thinked/sleeped about your approach (fetching all data on reading/fetching all recordings).

When i'll got you right, i'll see the following issue:

- Client 1 & 2 starts up
- They fetching new/changed data from DMS on loading the recordings
- Client 1 updates an lastplayedposition of an recording
- Client 2 is watching the same recording and doesnt get the update from client 1

Can you please go into detail how you want to LIVE sync data with your approach?

I cant see the benefits from always syncing in the background (maybe with an unique time identifier or similar).

Please review and merge.